### PR TITLE
Fix the issue when calculating score from classification model

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytorch-model-data-science"
-version = "0.1.0"
+version = "0.1.1"
 description = ""
 authors = ["Yankai Wang <yankai.wang@momox.biz>"]
 

--- a/pytorch_model_data_science/model.py
+++ b/pytorch_model_data_science/model.py
@@ -13,15 +13,28 @@ from torch import nn
 class PyTorchEstimator(base.BaseEstimator, base.RegressorMixin):
     """The class to define a sklearn estimator from PyTorch model"""
 
-    def __init__(self, model: nn.Module) -> None:
+    def __init__(self, model: nn.Module, target: str) -> None:
         """Constructor
 
         Parameters
         ----------
         model: nn.Module
             the model from PyTorch
+        target: str
+            the task what the model does, including classification and
+            regression
         """
         self.model = model
+        self.target = target
+
+        self._check_valid_target()
+
+    def _check_valid_target(self) -> None:
+        """Checks if the target is valid"""
+        assert self.target in [
+            "classification",
+            "regression",
+        ], f"Wrong target name: {self.target}"
 
     def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None) -> None:
         """Simulates fit process
@@ -91,7 +104,10 @@ class PyTorchEstimator(base.BaseEstimator, base.RegressorMixin):
             the scoare
         """
         y_pred = self.predict(X)
-        return metrics.mean_squared_error(y, y_pred)
+        if self.target == "classification":
+            return metrics.f1_score(y, y_pred > 0.5)
+        elif self.target == "regression":
+            return metrics.mean_squared_error(y, y_pred)
 
 
 # linear network for regression


### PR DESCRIPTION
Bump the version to 0.1.1

Now the customized sklearn estimator is only compatible to calculate the score by a regression PyTorch model. In this PR, another argument `target` is introduced to the class object, which can indicate if the model is a classifier or a regressor, and accordingly the corresponding score can be calculated.