### PR TITLE
Update author name and email

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "pytorch-model-data-science"
 version = "0.1.1"
 description = ""
-authors = ["Yankai Wang <yankai.wang@momox.biz>"]
+authors = ["YankaiW <wyk.uestc@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
When creating this repo by poetry, poetry used the default working name and email address as the author data, which is not correct, since this repo should be worked from private account. In this PR, fix this issue, to make author data consistent with Github account.