### PR TITLE
Use Dataset in validation functions

### DIFF
--- a/pytorch_model_data_science/validation.py
+++ b/pytorch_model_data_science/validation.py
@@ -5,12 +5,12 @@ from typing import Any, Tuple
 
 import torch
 from sklearn import metrics
-from torch.utils.data import DataLoader
+from torch.utils.data import Dataset
 
 
 def test_classifier_accuracy(
     network: torch.nn.Module,
-    dataloader: DataLoader,
+    dataset: Dataset,
     loss_fn: Any,
     model_type: str = "DNN",
 ) -> Tuple[float, float, float, float]:
@@ -20,8 +20,8 @@ def test_classifier_accuracy(
     ----------
     network: torch.nn.Module
         the trained pytorch model
-    dataloader: DataLoader
-        the dataloader for testing
+    dataset: Dataset
+        the dataset for testing
     loss_fn:
         loss function
     model_type: str, default DNN
@@ -39,24 +39,24 @@ def test_classifier_accuracy(
         f1 score
     """
     # transform data
-    test_data = dataloader.dataset[:][0]
+    test_data = dataset[:][0]
     if model_type in ["CNN", "LSTM"]:
         test_data = test_data[:, None, :]
     network.eval()
     with torch.no_grad():
         pred = network(test_data)
-        loss = loss_fn(pred, dataloader.dataset[:][1]).item()
+        loss = loss_fn(pred, dataset[:][1]).item()
     # metrics
     precision = metrics.precision_score(
-        dataloader.dataset[:][1].numpy().flatten(),
+        dataset[:][1].numpy().flatten(),
         pred.detach().numpy().flatten() > 0.5,
     )
     recall = metrics.recall_score(
-        dataloader.dataset[:][1].numpy().flatten(),
+        dataset[:][1].numpy().flatten(),
         pred.detach().numpy().flatten() > 0.5,
     )
     f1 = metrics.f1_score(
-        dataloader.dataset[:][1].numpy().flatten(),
+        dataset[:][1].numpy().flatten(),
         pred.detach().numpy().flatten() > 0.5,
     )
     return loss, precision, recall, f1
@@ -64,7 +64,7 @@ def test_classifier_accuracy(
 
 def test_regressor_accuracy(
     network: torch.nn.Module,
-    dataloader: DataLoader,
+    dataset: Dataset,
     loss_fn: Any,
     model_type: str = "DNN",
 ) -> Tuple[float, float, float, float]:
@@ -74,8 +74,8 @@ def test_regressor_accuracy(
     ----------
     network: torch.nn.Module
         the trained pytorch model
-    dataloader: DataLoader
-        the dataloader for testing
+    dataloader: Dataset
+        the dataset for testing
     loss_fn:
         loss function
     model_type: str, default DNN
@@ -93,25 +93,25 @@ def test_regressor_accuracy(
         f1 score
     """
     # transform data
-    test_data = dataloader.dataset[:][0]
+    test_data = dataset[:][0]
     if model_type in ["CNN", "LSTM"]:
         test_data = test_data[:, None, :]
 
     network.eval()
     with torch.no_grad():
         pred = network(test_data)
-        loss = loss_fn(pred, dataloader[:][1]).item()
+        loss = loss_fn(pred, dataset[:][1]).item()
     # metrics
     mae = metrics.mean_absolute_error(
-        dataloader[:][1].numpy().flatten(),
+        dataset[:][1].numpy().flatten(),
         pred.detach().numpy().flatten(),
     )
     mse = metrics.mean_squared_error(
-        dataloader[:][1].numpy().flatten(),
+        dataset[:][1].numpy().flatten(),
         pred.detach().numpy().flatten(),
     )
     r2 = metrics.r2_score(
-        dataloader[:][1].numpy().flatten(),
+        dataset[:][1].numpy().flatten(),
         pred.detach().numpy().flatten(),
     )
     return loss, mae, mse, r2


### PR DESCRIPTION
Use Dataset, instead of DataLoader, in validation functions. The reason to do this is, the last data generation before hyperparameter tuning is Dataset, which can be used for validation directly, and no need to generate DataLoader anymore.