### PR TITLE
Remove model_type argument from validation functions

### DIFF
--- a/pytorch_model_data_science/train.py
+++ b/pytorch_model_data_science/train.py
@@ -13,7 +13,6 @@ def train_classifier(
     network: torch.nn.Module,
     dataset: Dataset,
     loss_fn: Any,
-    model_type: str,
     optimizer: Any,
     class_weight: bool = False,
     batch_size: int = 1024,
@@ -29,8 +28,6 @@ def train_classifier(
         the training dataset
     loss_fn: Any
         the loss function
-    model_type: str
-        the type of the model, including DNN, CNN, LSTM
     optimizer: Any
         the optimizer
     class_weight: bool, default False
@@ -39,9 +36,6 @@ def train_classifier(
         the number of the batch size
     verbose: int, default 0
     """
-    if model_type in ["CNN", "LSTM"]:
-        dataset[:][0] = dataset[:][0][:, None, :]
-
     size = len(dataset)
     running_loss = 0.0
     network.train()
@@ -109,7 +103,6 @@ def train_regressor(
     network: torch.nn.Module,
     dataset: Dataset,
     loss_fn: Any,
-    model_type: str,
     optimizer: Any,
     batch_size: int = 1024,
     verbose: int = 0,
@@ -124,17 +117,12 @@ def train_regressor(
         the training dataset
     loss_fn: Any
         the loss function
-    model_type: str
-        the type of the model, including DNN, CNN, LSTM
     optimizer: Any
         the optimizer
     batch_size: int, default 1024
         the number of the batch size
     verbose: int, default 0
     """
-    if model_type in ["CNN", "LSTM"]:
-        dataset[:][0] = dataset[:][0][:, None, :]
-
     size = len(dataset)
     running_loss = 0.0
     network.train()

--- a/pytorch_model_data_science/validation.py
+++ b/pytorch_model_data_science/validation.py
@@ -12,7 +12,6 @@ def test_classifier_accuracy(
     network: torch.nn.Module,
     dataset: Dataset,
     loss_fn: Any,
-    model_type: str = "DNN",
 ) -> Tuple[float, float, float, float]:
     """Tests trained model
 
@@ -24,8 +23,6 @@ def test_classifier_accuracy(
         the dataset for testing
     loss_fn:
         loss function
-    model_type: str, default DNN
-        the name of the model
 
     Returns
     -------
@@ -38,13 +35,9 @@ def test_classifier_accuracy(
     float
         f1 score
     """
-    # transform data
-    test_data = dataset[:][0]
-    if model_type in ["CNN", "LSTM"]:
-        test_data = test_data[:, None, :]
     network.eval()
     with torch.no_grad():
-        pred = network(test_data)
+        pred = network(dataset[:][0])
         loss = loss_fn(pred, dataset[:][1]).item()
     # metrics
     precision = metrics.precision_score(
@@ -66,7 +59,6 @@ def test_regressor_accuracy(
     network: torch.nn.Module,
     dataset: Dataset,
     loss_fn: Any,
-    model_type: str = "DNN",
 ) -> Tuple[float, float, float, float]:
     """Tests trained model
 
@@ -78,8 +70,6 @@ def test_regressor_accuracy(
         the dataset for testing
     loss_fn:
         loss function
-    model_type: str, default DNN
-        the name of the model
 
     Returns
     -------
@@ -92,14 +82,9 @@ def test_regressor_accuracy(
     float
         f1 score
     """
-    # transform data
-    test_data = dataset[:][0]
-    if model_type in ["CNN", "LSTM"]:
-        test_data = test_data[:, None, :]
-
     network.eval()
     with torch.no_grad():
-        pred = network(test_data)
+        pred = network(dataset[:][0])
         loss = loss_fn(pred, dataset[:][1]).item()
     # metrics
     mae = metrics.mean_absolute_error(


### PR DESCRIPTION
In order to simplify function structures, to remove model_type from validation functions, and the feature matrix shape should be well-shaped beforehand.

Besides, also remove model_type arguments from training function accordingly.